### PR TITLE
Added nestjs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,8 @@ Please take a quick look at the [contribution guidelines](https://github.com/Env
 | <img src="https://img.shields.io/badge/json%20web%20tokens-323330?style=for-the-badge&logo=json-web-tokens&logoColor=pink" />        | `https://img.shields.io/badge/json%20web%20tokens-323330?style=for-the-badge&logo=json-web-tokens&logoColor=pink`        |
 | <img src="https://img.shields.io/badge/npm-CB3837?style=for-the-badge&logo=npm&logoColor=white" />                                   | `https://img.shields.io/badge/npm-CB3837?style=for-the-badge&logo=npm&logoColor=white`                                   |
 | <img src="https://img.shields.io/badge/Next.js-000?logo=nextdotjs&logoColor=fff&style=for-the-badge" /> | `https://img.shields.io/badge/Next.js-000?logo=nextdotjs&logoColor=fff&style=for-the-badge` |
-| <img src="https://img.shields.io/badge/Symfony-000?logo=symfony&logoColor=fff&style=for-the-badge" alt="Symfony Badge">  | `https://img.shields.io/badge/Symfony-000?logo=symfony&logoColor=fff&style=for-the-badge` | 
+| <img src="https://img.shields.io/badge/Symfony-000?logo=symfony&logoColor=fff&style=for-the-badge" alt="Symfony Badge">  | `https://img.shields.io/badge/Symfony-000?logo=symfony&logoColor=fff&style=for-the-badge` |
+| <img src="https://img.shields.io/badge/Nestjs-E0234E?style=for-the-badge&logo=nestjs&logoColor=white" alt="NestJS Badge">  | `https://img.shields.io/badge/Nestjs-E0234E?style=for-the-badge&logo=nestjs&logoColor=white` |
 
 <br>
 


### PR DESCRIPTION
I discovered that there was no badge for Nestjs. So I followed the same format and added the badge for Nestjs at the end of the Skill section where the likes of Nodejs was located

### Badge Name and Link

{Nestjs} | `[[Badge Link](https://img.shields.io/badge/Nestjs-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://img.shields.io/badge/Nestjs-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)`

---

## Badge Category

{Skills}

---

- [✅] I have read the [Contribution Guidelines]